### PR TITLE
Add rider level presets, lighting commands and analytics utilities

### DIFF
--- a/ASSET_MANIFEST.md
+++ b/ASSET_MANIFEST.md
@@ -1,0 +1,13 @@
+# Asset Manifest
+
+- assets/icons/xray_app_icon.svg
+- assets/icons/ble_board.svg
+- assets/icons/speed.svg
+- assets/icons/battery.svg
+- assets/icons/temperature.svg
+- assets/icons/lightbulb.svg
+- assets/icons/brake.svg
+- assets/icons/turbo.svg
+- assets/icons/badge_star.svg
+- assets/fonts/Inter-Regular.ttf
+- assets/fonts/Inter-SemiBold.ttf

--- a/PARTNER_BRIEF.md
+++ b/PARTNER_BRIEF.md
@@ -11,6 +11,10 @@ The X-Ray Companion app offers live dashboard, logging, safety alerts and OTA up
 - Mock mode for demo
 - CI builds for Android/iOS
 
+## Rider Levels & Lighting Integration
+- App defines beginner through turbo levels with encoded accel/brake curves
+- Lighting service handles headlight, brake light and addressable LEDs
+
 ## What We Need
 - GATT UUIDs and packet layouts
 - DFU documentation

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # exway Companion
 
-A Flutter companion app for Exway electric skateboards. It connects over BLE to provide live telemetry, ride logging, and firmware updates. The app ships with a mock profile so you can explore the UI without hardware.
+A Flutter companion app for Exway electric skateboards. It connects over BLE to provide live telemetry, ride logging, rider levels, lighting control, and firmware updates. The app ships with a mock profile so you can explore the UI without hardware.
+
+## Features
+
+- Rider levels L1–L4 with turbo and custom curves
+- Lighting commands for headlight, brake light and addressable LEDs
+- Route logging and ride analytics (speed, distance, energy)
+- Badge engine for milestones
+- Support chat and accessories shop links
+- Mock profile simulating telemetry and LED acknowledgements
 
 
 ## Quick Start

--- a/TECH_SPEC.md
+++ b/TECH_SPEC.md
@@ -14,12 +14,32 @@
 | faults_bitfield | bits |
 
 ## BLE Contract
-- Service UUID: 0xA0A0
-- Telemetry Char: 0xA001 (notify)
-- Command Char: 0xA002 (write JSON)
+
+- Control Service UUID: 0xA0A0
+  - Telemetry Char: 0xA001 (notify)
+  - Command Char: 0xA002 (write JSON)
+- Lighting Service UUID: 0xB0B0
+  - Command Char: 0xB001 (write JSON/CBOR)
+    - `{ "cmd":"headlight","state":"on"|"off"|"auto" }`
+    - `{ "cmd":"rear","pattern":"solid_red"|"brake"|"brake_strobe","intensity":0..100 }`
+    - `{ "cmd":"ws2811","channel":0|1,"pattern":"custom","data":[...] }`
+
+## Curves Encoding
+- Accel/decel curves are piecewise Bezier defined by 5 normalized control points
+- Utility samples curve to 0..1 lookup table before transmit
+
+## Brake Detection
+- Uses two consecutive telemetry samples
+- Compute `a = Δv/Δt`; brake event when `a <= −0.8 m/s²`
+
+## Sun Time Algorithm
+- NOAA solar position equations computed on-device
+- Inputs: date, latitude, longitude, timezone offset
+- Outputs: sunrise and sunset in local time
 
 ## Database Schema
-Tables: rides, samples, alerts. Data retained locally.
+Tables: rides, samples, alerts, routes, mileage_totals, firmware_history, badges.
+Default badges seeded on first run.
 
 ## Safety Heuristics
 Simple thermal headroom and voltage sag estimators.

--- a/UX_GUIDE.md
+++ b/UX_GUIDE.md
@@ -4,3 +4,6 @@
 - Sparklines show trends for speed, power, temperature
 - Alerts appear as subtle toasts
 - Accessibility considered with large type and contrast
+- Every interactive control exposes a long‑press or `?` tooltip with plain
+  language guidance
+- LEDs screen provides headlight and brake light toggles with live preview

--- a/app/lib/ble/board_profile.dart
+++ b/app/lib/ble/board_profile.dart
@@ -13,7 +13,23 @@ abstract class BoardProfile {
   Guid get commandChar;
   Guid? get configChar;
 
+  /// Optional lighting service for vendors that expose LED control.
+  Guid? get lightingServiceId;
+
+  /// Optional characteristic used to transmit lighting commands.
+  Guid? get lightingChar;
+
   Telemetry parseTelemetry(Uint8List bytes);
-  Future<void> encodeAndWriteCommand(
-      BluetoothDevice device, BoardCommand cmd);
+
+  /// Sends a rider control command such as mode or limits.
+  Future<void> sendRiderCommand(
+      BluetoothDevice device, RiderCommand cmd);
+
+  /// Sends a lighting command when [lightingSupported] is true.
+  Future<void> sendLightingCommand(
+      BluetoothDevice device, LightingCommand cmd);
+
+  /// Whether this profile exposes the lighting service.
+  bool get lightingSupported =>
+      lightingServiceId != null && lightingChar != null;
 }

--- a/app/lib/ble/exway_profile.dart
+++ b/app/lib/ble/exway_profile.dart
@@ -9,8 +9,16 @@ import '../models/commands.dart';
 class ExwayProfile implements BoardProfile {
   // TODO: Replace with real UUIDs when provided.
   static final Guid _serviceId = Guid('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA');
-  static final Guid _telemetryChar = Guid('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAA1');
-  static final Guid _commandChar = Guid('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAA2');
+  static final Guid _telemetryChar =
+      Guid('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAA1');
+  static final Guid _commandChar =
+      Guid('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAA2');
+
+  // Lighting service UUIDs to be provided by vendor.
+  static final Guid _lightingService =
+      Guid('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAB0B0');
+  static final Guid _lightingChar =
+      Guid('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAB001');
 
   @override
   String get brand => 'Exway';
@@ -31,6 +39,12 @@ class ExwayProfile implements BoardProfile {
   Guid? get configChar => null;
 
   @override
+  Guid? get lightingServiceId => _lightingService;
+
+  @override
+  Guid? get lightingChar => _lightingChar;
+
+  @override
   Telemetry parseTelemetry(Uint8List bytes) {
     // TODO: parse little-endian floats from bytes according to vendor spec.
     return Telemetry(
@@ -48,8 +62,14 @@ class ExwayProfile implements BoardProfile {
   }
 
   @override
-  Future<void> encodeAndWriteCommand(
-      BluetoothDevice device, BoardCommand cmd) async {
+  Future<void> sendRiderCommand(
+      BluetoothDevice device, RiderCommand cmd) async {
     // TODO: encode JSON/CBOR into bytes and write to characteristic.
+  }
+
+  @override
+  Future<void> sendLightingCommand(
+      BluetoothDevice device, LightingCommand cmd) async {
+    // TODO: encode JSON/CBOR into bytes and write to lighting characteristic.
   }
 }

--- a/app/lib/ble/mock_profile.dart
+++ b/app/lib/ble/mock_profile.dart
@@ -26,6 +26,14 @@ class MockProfile implements BoardProfile {
   @override
   Guid? get configChar => null;
 
+  @override
+  Guid? get lightingServiceId =>
+      Guid('00000000-0000-0000-0000-00000000B0B0');
+
+  @override
+  Guid? get lightingChar =>
+      Guid('00000000-0000-0000-0000-00000000B001');
+
   Stream<Telemetry> startMockStream() {
     return Stream.periodic(const Duration(milliseconds: 100), (i) {
       final t = i / 10.0;
@@ -63,6 +71,15 @@ class MockProfile implements BoardProfile {
   }
 
   @override
-  Future<void> encodeAndWriteCommand(
-      BluetoothDevice device, BoardCommand cmd) async {}
+  Future<void> sendRiderCommand(
+      BluetoothDevice device, RiderCommand cmd) async {
+    // In mock mode we simply await a short delay to simulate ACK.
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+
+  @override
+  Future<void> sendLightingCommand(
+      BluetoothDevice device, LightingCommand cmd) async {
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
 }

--- a/app/lib/data/db.dart
+++ b/app/lib/data/db.dart
@@ -35,12 +35,75 @@ class Alerts extends Table {
   TextColumn get meta => text().nullable()();
 }
 
-@DriftDatabase(tables: [Rides, Samples, Alerts])
+class Routes extends Table {
+  IntColumn get id => integer().autoIncrement();
+  IntColumn get rideId => integer()();
+  TextColumn get polyline => text()();
+}
+
+class MileageTotals extends Table {
+  IntColumn get id => integer().autoIncrement();
+  RealColumn get totalMiles => real().withDefault(const Constant(0))();
+}
+
+class FirmwareHistory extends Table {
+  IntColumn get id => integer().autoIncrement();
+  TextColumn get version => text()();
+  DateTimeColumn get ts => dateTime()();
+}
+
+class Badges extends Table {
+  IntColumn get id => integer().autoIncrement();
+  TextColumn get key => text()();
+  BoolColumn get earned => boolean().withDefault(const Constant(false))();
+  DateTimeColumn get earnedTs => dateTime().nullable()();
+}
+
+@DriftDatabase(
+    tables: [
+  Rides,
+  Samples,
+  Alerts,
+  Routes,
+  MileageTotals,
+  FirmwareHistory,
+  Badges
+])
 class AppDatabase extends _$AppDatabase {
   AppDatabase() : super(_open());
 
   @override
-  int get schemaVersion => 1;
+  int get schemaVersion => 2;
+
+  @override
+  MigrationStrategy get migration => MigrationStrategy(onCreate: (m) async {
+        await m.createAll();
+        await batch((b) {
+          b.insertAll(badges, [
+            BadgesCompanion.insert(key: 'first_10'),
+            BadgesCompanion.insert(key: 'century'),
+            BadgesCompanion.insert(key: 'commute_streak'),
+            BadgesCompanion.insert(key: 'top_speed_20'),
+            BadgesCompanion.insert(key: 'night_rider'),
+          ]);
+        });
+      }, onUpgrade: (m, from, to) async {
+        if (from == 1) {
+          await m.createTable(routes);
+          await m.createTable(mileageTotals);
+          await m.createTable(firmwareHistory);
+          await m.createTable(badges);
+          await batch((b) {
+            b.insertAll(badges, [
+              BadgesCompanion.insert(key: 'first_10'),
+              BadgesCompanion.insert(key: 'century'),
+              BadgesCompanion.insert(key: 'commute_streak'),
+              BadgesCompanion.insert(key: 'top_speed_20'),
+              BadgesCompanion.insert(key: 'night_rider'),
+            ]);
+          });
+        }
+      });
 }
 
 LazyDatabase _open() {

--- a/app/lib/data/db.g.dart
+++ b/app/lib/data/db.g.dart
@@ -5,7 +5,7 @@ class _$AppDatabase extends GeneratedDatabase {
   _$AppDatabase(QueryExecutor e) : super(e);
 
   @override
-  int get schemaVersion => 1;
+  int get schemaVersion => 2;
 
   @override
   Iterable<TableInfo<Table, Object?>> get allTables => const [];

--- a/app/lib/models/commands.dart
+++ b/app/lib/models/commands.dart
@@ -1,16 +1,64 @@
-sealed class BoardCommand {}
-
-class SetMode extends BoardCommand {
-  final int mode;
-  SetMode(this.mode);
+sealed class RiderCommand {
+  const RiderCommand();
 }
 
-class SetLights extends BoardCommand {
-  final bool on;
-  SetLights(this.on);
+class SetLevel extends RiderCommand {
+  final int level;
+  const SetLevel(this.level);
 }
 
-class SetLimit extends BoardCommand {
-  final double amps;
-  SetLimit(this.amps);
+class SetTurbo extends RiderCommand {
+  final bool enabled;
+  const SetTurbo(this.enabled);
+}
+
+class SetLimits extends RiderCommand {
+  final double topMph;
+  final List<double> accelCurve;
+  final List<double> decelCurve;
+  const SetLimits({
+    required this.topMph,
+    required this.accelCurve,
+    required this.decelCurve,
+  });
+}
+
+sealed class LightingCommand {
+  const LightingCommand();
+  Map<String, dynamic> toJson();
+}
+
+class HeadlightCommand extends LightingCommand {
+  final String state; // 'on', 'off', 'auto'
+  const HeadlightCommand(this.state);
+  @override
+  Map<String, dynamic> toJson() => {
+        'cmd': 'headlight',
+        'state': state,
+      };
+}
+
+class RearLightCommand extends LightingCommand {
+  final String pattern; // 'solid_red', 'brake', 'brake_strobe'
+  final int intensity; // 0-100
+  const RearLightCommand(this.pattern, this.intensity);
+  @override
+  Map<String, dynamic> toJson() => {
+        'cmd': 'rear',
+        'pattern': pattern,
+        'intensity': intensity,
+      };
+}
+
+class Ws2811Command extends LightingCommand {
+  final int channel;
+  final List<int> data;
+  const Ws2811Command({required this.channel, required this.data});
+  @override
+  Map<String, dynamic> toJson() => {
+        'cmd': 'ws2811',
+        'channel': channel,
+        'pattern': 'custom',
+        'data': data,
+      };
 }

--- a/app/lib/utils/brake_detection.dart
+++ b/app/lib/utils/brake_detection.dart
@@ -1,0 +1,11 @@
+import '../models/telemetry.dart';
+
+/// Returns true when the deceleration between [prev] and [curr] exceeds
+/// [threshold] m/s^2.
+bool detectBrake(Telemetry prev, Telemetry curr, {double threshold = -0.8}) {
+  final dv = curr.speedMps - prev.speedMps;
+  final dt = curr.ts.difference(prev.ts).inMilliseconds / 1000.0;
+  if (dt <= 0) return false;
+  final accel = dv / dt;
+  return accel <= threshold;
+}

--- a/app/lib/utils/curves.dart
+++ b/app/lib/utils/curves.dart
@@ -1,0 +1,44 @@
+/// Samples a curve defined by five control points into [samples] values.
+/// Points must be in the range 0..1.
+List<double> sampleCurve(List<double> points, {int samples = 21}) {
+  if (points.length != 5) {
+    throw ArgumentError('expected exactly 5 control points');
+  }
+  final result = <double>[];
+  for (var i = 0; i < samples; i++) {
+    final t = i / (samples - 1);
+    final seg = (t * 4).floor().clamp(0, 3);
+    final localT = t * 4 - seg;
+    final p0 = points[seg];
+    final p1 = points[seg + 1];
+    // Simple cubic easing between p0 and p1.
+    final eased = _cubicEase(p0, p1, localT);
+    result.add(eased.clamp(0.0, 1.0));
+  }
+  return result;
+}
+
+double _cubicEase(double a, double b, double t) {
+  // Smoothstep interpolation between two points.
+  final tt = t * t * (3 - 2 * t);
+  return a + (b - a) * tt;
+}
+
+/// Preset rider levels with top speed and default curves.
+class RiderLevel {
+  final double topMph;
+  final List<double> accel;
+  final List<double> decel;
+  const RiderLevel(this.topMph, this.accel, this.decel);
+}
+
+final Map<int, RiderLevel> levelPresets = {
+  1: RiderLevel(10, [0, 0.2, 0.4, 0.6, 1], [0, 0.2, 0.4, 0.6, 1]),
+  2: RiderLevel(15, [0, 0.3, 0.5, 0.7, 1], [0, 0.3, 0.5, 0.7, 1]),
+  3: RiderLevel(22, [0, 0.4, 0.6, 0.8, 1], [0, 0.4, 0.6, 0.8, 1]),
+  4: RiderLevel(30, [0, 0.5, 0.7, 0.9, 1], [0, 0.5, 0.7, 0.9, 1]),
+};
+
+RiderLevel turboPreset(RiderLevel base) {
+  return RiderLevel(base.topMph, [0, 0.6, 0.8, 0.95, 1], [0, 0.6, 0.8, 0.95, 1]);
+}

--- a/app/lib/utils/sun_times.dart
+++ b/app/lib/utils/sun_times.dart
@@ -1,0 +1,51 @@
+import 'dart:math' as math;
+
+class SunTimes {
+  final DateTime sunrise;
+  final DateTime sunset;
+  const SunTimes(this.sunrise, this.sunset);
+}
+
+double _degToRad(double deg) => deg * math.pi / 180.0;
+double _radToDeg(double rad) => rad * 180.0 / math.pi;
+
+/// Computes sunrise and sunset for [date] at [lat]/[lon].
+/// [tzOffsetMinutes] is the timezone offset from UTC in minutes.
+SunTimes computeSunTimes(
+    DateTime date, double lat, double lon, int tzOffsetMinutes) {
+  // Algorithm based on NOAA solar calculations.
+  final day = date.toUtc().difference(DateTime.utc(date.year, 1, 1)).inDays + 1;
+  final gamma = 2 * math.pi / 365 * (day - 1 + ((date.hour - 12) / 24));
+
+  final eqtime = 229.18 *
+      (0.000075 +
+          0.001868 * math.cos(gamma) -
+          0.032077 * math.sin(gamma) -
+          0.014615 * math.cos(2 * gamma) -
+          0.040849 * math.sin(2 * gamma));
+
+  final decl = 0.006918 -
+      0.399912 * math.cos(gamma) +
+      0.070257 * math.sin(gamma) -
+      0.006758 * math.cos(2 * gamma) +
+      0.000907 * math.sin(2 * gamma) -
+      0.002697 * math.cos(3 * gamma) +
+      0.00148 * math.sin(3 * gamma);
+
+  final haSunrise = math.acos(
+      math.cos(_degToRad(90.833)) /
+              (math.cos(_degToRad(lat)) * math.cos(decl)) -
+          math.tan(_degToRad(lat)) * math.tan(decl));
+
+  final sunriseT = 720 - 4 * (lon + _radToDeg(haSunrise)) - eqtime;
+  final sunsetT = 720 - 4 * (lon - _radToDeg(haSunrise)) - eqtime;
+
+  DateTime sunriseUtc =
+      DateTime.utc(date.year, date.month, date.day).add(Duration(minutes: sunriseT.round()));
+  DateTime sunsetUtc =
+      DateTime.utc(date.year, date.month, date.day).add(Duration(minutes: sunsetT.round()));
+
+  final sunrise = sunriseUtc.add(Duration(minutes: tzOffsetMinutes));
+  final sunset = sunsetUtc.add(Duration(minutes: tzOffsetMinutes));
+  return SunTimes(sunrise, sunset);
+}

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -23,5 +23,6 @@ dev_dependencies:
   integration_test:
     sdk: flutter
   golden_toolkit: ^0.15.0
+  test: ^1.24.0
 flutter:
   uses-material-design: true

--- a/app/test/brake_test.dart
+++ b/app/test/brake_test.dart
@@ -1,0 +1,33 @@
+import 'package:test/test.dart';
+import 'package:xray_companion/models/telemetry.dart';
+import 'package:xray_companion/utils/brake_detection.dart';
+
+void main() {
+  test('detects braking when decel below threshold', () {
+    final prev = Telemetry(
+      ts: DateTime.now(),
+      speedMps: 5,
+      volts: 40,
+      amps: 0,
+      escTempC: 0,
+      motorTempC: 0,
+      throttlePct: 0,
+      brakePct: 0,
+      rideMode: 0,
+      faultsBits: 0,
+    );
+    final curr = Telemetry(
+      ts: prev.ts.add(const Duration(seconds: 1)),
+      speedMps: 4,
+      volts: prev.volts,
+      amps: prev.amps,
+      escTempC: prev.escTempC,
+      motorTempC: prev.motorTempC,
+      throttlePct: prev.throttlePct,
+      brakePct: prev.brakePct,
+      rideMode: prev.rideMode,
+      faultsBits: prev.faultsBits,
+    );
+    expect(detectBrake(prev, curr, threshold: -0.5), isTrue);
+  });
+}

--- a/app/test/curve_test.dart
+++ b/app/test/curve_test.dart
@@ -1,0 +1,10 @@
+import 'package:test/test.dart';
+import 'package:xray_companion/utils/curves.dart';
+
+void main() {
+  test('sampling produces values from 0 to 1', () {
+    final samples = sampleCurve([0, 0.5, 0.8, 0.9, 1], samples: 5);
+    expect(samples.first, closeTo(0, 1e-6));
+    expect(samples.last, closeTo(1, 1e-6));
+  });
+}

--- a/app/test/sun_times_test.dart
+++ b/app/test/sun_times_test.dart
@@ -1,0 +1,10 @@
+import 'package:test/test.dart';
+import 'package:xray_companion/utils/sun_times.dart';
+
+void main() {
+  test('computes sunrise and sunset roughly', () {
+    final date = DateTime.utc(2024, 6, 1);
+    final times = computeSunTimes(date, 37.7749, -122.4194, 0);
+    expect(times.sunrise.isBefore(times.sunset), isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- expand board profile with lighting service and rider commands
- add curve sampling, sun time and brake detection utilities
- extend database schema for routes, mileage, firmware history and badges
- document rider levels, lighting integration and asset manifest

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abc731aee48327a9400b96794c9a48