### PR TITLE
fix: clean telemetry parsing and mock timing

### DIFF
--- a/app/lib/ble/exway_profile.dart
+++ b/app/lib/ble/exway_profile.dart
@@ -61,23 +61,25 @@ class ExwayProfile implements BoardProfile {
   Telemetry parseTelemetry(Uint8List bytes) {
     final bd = ByteData.sublistView(bytes);
     int offset = 0;
+
     final ms = bd.getUint32(offset, Endian.little);
     offset += 4;
-    double _f32() {
+
+    double readF32() {
       final v = bd.getFloat32(offset, Endian.little);
       offset += 4;
       return v;
     }
 
-    final speed = _f32();
-    final volts = _f32();
-    final amps = _f32();
-    final esc = _f32();
-    final motor = _f32();
-    final throttle = _f32();
-    final brake = _f32();
+    final speed = readF32();
+    final volts = readF32();
+    final amps = readF32();
+    final esc = readF32();
+    final motor = readF32();
+    final throttle = readF32();
+    final brake = readF32();
     final rideMode = bd.getUint8(offset++);
-    final faults = bd.getUint8(offset);
+    final faults = bd.getUint8(offset++);
 
     return Telemetry(
       ts: DateTime.now(),

--- a/app/lib/ble/mock_profile.dart
+++ b/app/lib/ble/mock_profile.dart
@@ -50,12 +50,12 @@ class MockProfile implements BoardProfile {
       Guid('00000000-0000-0000-0000-00000000C001');
 
   Stream<Telemetry> startMockStream() {
-    return Stream.periodic(const Duration(milliseconds: 100), (i) {
-      final t = i / 10.0;
+    return Stream.periodic(const Duration(milliseconds: 100), (_) {
       _ms += 100;
-      _volts -= 0.0005; // slow drain
-      _escTemp += 0.01;
-      _motorTemp += 0.015;
+      final t = _ms / 1000.0;
+      _volts = math.max(30.0, _volts - 0.0005); // slow drain, clamp at 30 V
+      _escTemp = math.min(100.0, _escTemp + 0.01);
+      _motorTemp = math.min(120.0, _motorTemp + 0.015);
       return Telemetry(
         ts: DateTime.now(),
         msSinceBoot: _ms,
@@ -74,14 +74,13 @@ class MockProfile implements BoardProfile {
 
   @override
   Telemetry parseTelemetry(Uint8List bytes) {
-    final now = DateTime.now();
     _ms += 100;
     final t = _ms / 1000.0;
-    _volts -= 0.0005;
-    _escTemp += 0.01;
-    _motorTemp += 0.015;
+    _volts = math.max(30.0, _volts - 0.0005);
+    _escTemp = math.min(100.0, _escTemp + 0.01);
+    _motorTemp = math.min(120.0, _motorTemp + 0.015);
     return Telemetry(
-      ts: now,
+      ts: DateTime.now(),
       msSinceBoot: _ms,
       speedMps: 8 + 2 * math.sin(t),
       volts: _volts,


### PR DESCRIPTION
## Summary
- ensure Exway telemetry parser assigns each metric once
- consolidate mock telemetry stream to single timer and realistic ranges

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abf5e12ac88327bd2cdd104234cbd7