### PR TITLE
feat: add plugin system and watch bridge stubs

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -1,0 +1,24 @@
+# Plugin System
+
+The app exposes a simple static plugin API. Plugins implement `XrayPlugin`
+and are registered in `lib/plugins/registry.dart`.
+
+```dart
+abstract class XrayPlugin {
+  String get id;
+  String get name;
+  Future<void> init(PluginContext ctx);
+}
+```
+
+`PluginContext` provides streams for telemetry and safety events and allows
+plugins to register commands or add menu items.
+
+Sample plugins live in `lib/plugins/`:
+* `sample_led_breathe.dart` – adds a menu item that triggers a mock LED
+  "breathe" effect.
+* `sample_telemetry_scaler.dart` – listens to telemetry and prints scaled
+  speed values for demo calibration.
+
+Plugins are discovered through the static list in `registry.dart`.
+Versioning follows semantic versioning aligned with the app version.

--- a/README.md
+++ b/README.md
@@ -37,3 +37,13 @@ See [PARTNER_BRIEF.md](PARTNER_BRIEF.md) and [TECH_SPEC.md](TECH_SPEC.md) for co
 | `XRAY_PREDICT_URL` | Optional range/hazard feed aggregator |
 
 If a variable is missing the app falls back to local-only behaviour.
+
+## Wearables
+
+A lightweight JSON bridge streams telemetry for watch companions. See
+[docs/WEARABLES.md](docs/WEARABLES.md) for details and example stub widgets.
+
+## Plugin System
+
+Developers can extend the app using the static plugin API. Sample plugins are
+included under `lib/plugins`. See [PLUGINS.md](PLUGINS.md) for guidance.

--- a/app/lib/models/safety_event.dart
+++ b/app/lib/models/safety_event.dart
@@ -1,0 +1,6 @@
+class SafetyEvent {
+  final DateTime ts;
+  final String message;
+
+  SafetyEvent({required this.ts, required this.message});
+}

--- a/app/lib/plugins/api.dart
+++ b/app/lib/plugins/api.dart
@@ -1,0 +1,40 @@
+import 'dart:async';
+import 'package:flutter/foundation.dart';
+
+import '../models/telemetry.dart';
+import '../models/safety_event.dart';
+
+/// Base interface for plugins.
+abstract class XrayPlugin {
+  String get id;
+  String get name;
+  Future<void> init(PluginContext ctx);
+}
+
+/// Context provided to plugins on initialization.
+class PluginContext {
+  final Stream<Telemetry> telemetry;
+  final Stream<SafetyEvent> safety;
+  final void Function(String id, Future<void> Function(Map<String, dynamic>) handler) registerCommand;
+  final void Function(PluginMenuItem item) addMenuItem;
+
+  PluginContext({
+    required this.telemetry,
+    required this.safety,
+    required this.registerCommand,
+    required this.addMenuItem,
+  });
+}
+
+/// Represents a simple menu item plugins may expose.
+class PluginMenuItem {
+  final String id;
+  final String title;
+  final VoidCallback onSelected;
+
+  const PluginMenuItem({
+    required this.id,
+    required this.title,
+    required this.onSelected,
+  });
+}

--- a/app/lib/plugins/registry.dart
+++ b/app/lib/plugins/registry.dart
@@ -1,0 +1,9 @@
+import 'api.dart';
+import 'sample_led_breathe.dart';
+import 'sample_telemetry_scaler.dart';
+
+/// Static plugin registry.
+final List<XrayPlugin> plugins = [
+  SampleLedBreathePlugin(),
+  SampleTelemetryScalerPlugin(),
+];

--- a/app/lib/plugins/sample_led_breathe.dart
+++ b/app/lib/plugins/sample_led_breathe.dart
@@ -1,0 +1,26 @@
+import 'api.dart';
+
+/// Demonstrates a simple plugin that exposes an LED "breathe" effect.
+class SampleLedBreathePlugin implements XrayPlugin {
+  @override
+  String get id => 'sample_led_breathe';
+
+  @override
+  String get name => 'LED Breathe';
+
+  @override
+  Future<void> init(PluginContext ctx) async {
+    ctx.addMenuItem(PluginMenuItem(
+      id: id,
+      title: 'LED Breathe',
+      onSelected: () {
+        ctx.registerCommand('led_breathe', (args) async {
+          // In mock mode we simply log the command.
+          // Real implementation would send lighting command with pattern=breathe.
+          // ignore: avoid_print
+          print('Mock: LED breathe command sent');
+        });
+      },
+    ));
+  }
+}

--- a/app/lib/plugins/sample_telemetry_scaler.dart
+++ b/app/lib/plugins/sample_telemetry_scaler.dart
@@ -1,0 +1,40 @@
+import 'dart:async';
+
+import '../models/telemetry.dart';
+import 'api.dart';
+
+/// Plugin that scales telemetry values for demo calibration.
+class SampleTelemetryScalerPlugin implements XrayPlugin {
+  @override
+  String get id => 'sample_telemetry_scaler';
+
+  @override
+  String get name => 'Telemetry Scaler';
+
+  StreamSubscription<Telemetry>? _sub;
+
+  @override
+  Future<void> init(PluginContext ctx) async {
+    _sub = ctx.telemetry.listen((t) {
+      final scaled = Telemetry(
+        ts: t.ts,
+        msSinceBoot: t.msSinceBoot,
+        speedMps: t.speedMps * 0.8,
+        volts: t.volts,
+        amps: t.amps,
+        escTempC: t.escTempC,
+        motorTempC: t.motorTempC,
+        throttlePct: t.throttlePct,
+        brakePct: t.brakePct,
+        rideMode: t.rideMode,
+        faultsBits: t.faultsBits,
+      );
+      // ignore: avoid_print
+      print('Scaled speed: ${scaled.speedMps}');
+    });
+  }
+
+  void dispose() {
+    _sub?.cancel();
+  }
+}

--- a/app/test/plugin_registry_test.dart
+++ b/app/test/plugin_registry_test.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xray_companion/plugins/registry.dart';
+
+void main() {
+  test('sample plugins are registered', () {
+    expect(plugins.any((p) => p.id == 'sample_led_breathe'), isTrue);
+    expect(plugins.any((p) => p.id == 'sample_telemetry_scaler'), isTrue);
+  });
+}

--- a/docs/WEARABLES.md
+++ b/docs/WEARABLES.md
@@ -1,0 +1,12 @@
+# Wearables
+
+A simple JSON bridge is provided for watch companions.
+
+The bridge emits snapshots like:
+
+```json
+{"speed":4.2,"battery_pct":75,"dist_today_km":1.0,"lock_state":1}
+```
+
+Demo Flutter widgets are available in `watch/wearos_stub.dart` and
+`watch/watchos_stub.dart` for WearOS and watchOS previews.

--- a/watch/bridge.dart
+++ b/watch/bridge.dart
@@ -1,0 +1,25 @@
+import 'dart:async';
+import 'dart:convert';
+
+/// Broadcasts compact JSON snapshots for watch clients.
+class WatchBridge {
+  final _controller = StreamController<String>.broadcast();
+  Stream<String> get stream => _controller.stream;
+
+  void update({
+    required double speedMps,
+    required double batteryPct,
+    required double distTodayKm,
+    required bool locked,
+  }) {
+    final payload = jsonEncode({
+      'speed': speedMps,
+      'battery_pct': batteryPct,
+      'dist_today_km': distTodayKm,
+      'lock_state': locked ? 1 : 0,
+    });
+    _controller.add(payload);
+  }
+
+  void dispose() => _controller.close();
+}

--- a/watch/watchos_stub.dart
+++ b/watch/watchos_stub.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'bridge.dart';
+
+/// Simple preview widget for watchOS build.
+class WatchOsPreview extends StatelessWidget {
+  const WatchOsPreview({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final bridge = WatchBridge()
+      ..update(speedMps: 4.2, batteryPct: 75, distTodayKm: 1.0, locked: true);
+    return StreamBuilder<String>(
+      stream: bridge.stream,
+      builder: (context, snap) => Center(child: Text(snap.data ?? '')),
+    );
+  }
+}

--- a/watch/wearos_stub.dart
+++ b/watch/wearos_stub.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'bridge.dart';
+
+/// Simple preview widget for WearOS build.
+class WearOsPreview extends StatefulWidget {
+  const WearOsPreview({super.key});
+
+  @override
+  State<WearOsPreview> createState() => _WearOsPreviewState();
+}
+
+class _WearOsPreviewState extends State<WearOsPreview> {
+  final bridge = WatchBridge();
+
+  @override
+  void initState() {
+    super.initState();
+    bridge.update(speedMps: 5, batteryPct: 80, distTodayKm: 2.5, locked: false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<String>(
+      stream: bridge.stream,
+      builder: (context, snap) {
+        return Center(child: Text(snap.data ?? '')); 
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    bridge.dispose();
+    super.dispose();
+  }
+}


### PR DESCRIPTION
## Summary
- introduce simple plugin API and sample plugins
- add JSON watch bridge with WearOS/watchOS preview widgets
- document plugin system and wearables

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abf982684c83278874f5fe9ead9437