### PR TITLE
docs: add asset placeholders and manifest

### DIFF
--- a/ASSET_MANIFEST.md
+++ b/ASSET_MANIFEST.md
@@ -11,6 +11,20 @@
 | assets/icons/brake.svg | SVG | Missing | Brake status icon. | 24x24 |
 | assets/icons/turbo.svg | SVG | Missing | Turbo mode emblem. | 24x24 |
 | assets/icons/badge_star.svg | SVG | Missing | Achievement badge star. | 24x24 |
+| assets/icons/sag_risk.svg | SVG | Missing | Voltage sag indicator icon. | 24x24 |
+| assets/icons/esc_temp.svg | SVG | Missing | ESC temperature icon. | 24x24 |
+| assets/icons/fault.svg | SVG | Missing | Fault log icon. | 24x24 |
+| assets/icons/maintenance.svg | SVG | Missing | Maintenance tips icon. | 24x24 |
+| assets/icons/diagnostics.svg | SVG | Missing | Diagnostics icon for settings. | 24x24 |
+| assets/icons/accessibility.svg | SVG | Missing | Accessibility settings icon. | 24x24 |
+| assets/icons/contrast.svg | SVG | Missing | High contrast toggle icon. | 24x24 |
+| assets/icons/developer.svg | SVG | Missing | Developer options icon. | 24x24 |
+| assets/icons/theft_ping.svg | SVG | Missing | Simulate theft ping icon. | 24x24 |
+| assets/icons/crowd_find.svg | SVG | Missing | Crowd find icon. | 24x24 |
+| assets/icons/mode_eco.svg | SVG | Missing | Eco mode icon. | 24x24 |
+| assets/icons/mode_sport.svg | SVG | Missing | Sport mode icon. | 24x24 |
+| assets/icons/mode_pro.svg | SVG | Missing | Pro mode icon. | 24x24 |
+| assets/icons/location.svg | SVG | Missing | Location pin for ownership screen. | 24x24 |
 | assets/fonts/Inter-Regular.ttf | TTF | Missing | Inter Regular font for UI text. | N/A |
 | assets/fonts/Inter-SemiBold.ttf | TTF | Missing | Inter SemiBold font for headings. | N/A |
 | assets/device-detail_definition.json | JSON | Present | Schema definitions for device details. | N/A |
@@ -18,3 +32,7 @@
 | assets/kit_dependence/DeviceKit.json | JSON | Present | Kit dependency listing. | N/A |
 | assets/dynamic_config.json | JSON | Present | Runtime configurable options. | N/A |
 | assets/configList.json | JSON | Present | Configuration list for mock profile. | N/A |
+| assets/images/no_connection.png | PNG | Missing | Illustration for no-board-connected state. | 256x256 |
+| assets/images/speed_gauge.png | PNG | Missing | Speed gauge illustration for ride screen. | 128x128 |
+| assets/images/ride_thumbnail.png | PNG | Missing | Thumbnail for ride list items. | 64x64 |
+| assets/images/update.png | PNG | Missing | Firmware update illustration. | 128x128 |

--- a/app/lib/ui/screens/connect_screen.dart
+++ b/app/lib/ui/screens/connect_screen.dart
@@ -16,6 +16,7 @@ class ConnectScreen extends StatelessWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
+            // TODO: Add illustration asset (e.g. assets/images/no_connection.png)
             const Text('No boards connected'),
             const SizedBox(height: 16),
             ElevatedButton(

--- a/app/lib/ui/screens/diagnostics_screen.dart
+++ b/app/lib/ui/screens/diagnostics_screen.dart
@@ -15,6 +15,7 @@ class DiagnosticsScreen extends StatelessWidget {
             label: s.batteryHealth,
             child: Card(
               child: ListTile(
+                // TODO: Add battery icon asset (e.g. assets/icons/battery.svg)
                 title: Text(s.batteryHealth),
                 subtitle: const Text('SOH: 95%'),
               ),
@@ -24,6 +25,7 @@ class DiagnosticsScreen extends StatelessWidget {
             label: s.sagRisk,
             child: Card(
               child: ListTile(
+                // TODO: Add voltage sag icon (e.g. assets/icons/sag_risk.svg)
                 title: Text(s.sagRisk),
                 subtitle: const Text('Low'),
               ),
@@ -33,6 +35,7 @@ class DiagnosticsScreen extends StatelessWidget {
             label: s.escTemps,
             child: Card(
               child: ListTile(
+                // TODO: Add temperature icon (e.g. assets/icons/esc_temp.svg)
                 title: Text(s.escTemps),
                 subtitle: const Text('ETA 10m'),
               ),
@@ -42,6 +45,7 @@ class DiagnosticsScreen extends StatelessWidget {
             label: s.faultsLog,
             child: Card(
               child: ListTile(
+                // TODO: Add fault log icon (e.g. assets/icons/fault.svg)
                 title: Text(s.faultsLog),
                 subtitle: const Text('No recent faults'),
               ),
@@ -51,6 +55,7 @@ class DiagnosticsScreen extends StatelessWidget {
             label: s.maintenanceTips,
             child: Card(
               child: ListTile(
+                // TODO: Add maintenance icon (e.g. assets/icons/maintenance.svg)
                 title: Text(s.maintenanceTips),
                 subtitle: const Text('Keep tires inflated.'),
               ),

--- a/app/lib/ui/screens/modes_screen.dart
+++ b/app/lib/ui/screens/modes_screen.dart
@@ -9,8 +9,11 @@ class ModesScreen extends StatelessWidget {
       appBar: AppBar(title: const Text('Modes')),
       body: ListView(
         children: const [
+          // TODO: Add Eco mode icon (e.g. assets/icons/mode_eco.svg)
           ListTile(title: Text('Eco')),
+          // TODO: Add Sport mode icon (e.g. assets/icons/mode_sport.svg)
           ListTile(title: Text('Sport')),
+          // TODO: Add Pro mode icon (e.g. assets/icons/mode_pro.svg)
           ListTile(title: Text('Pro')),
         ],
       ),

--- a/app/lib/ui/screens/ownership_screen.dart
+++ b/app/lib/ui/screens/ownership_screen.dart
@@ -10,6 +10,7 @@ class OwnershipScreen extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(title: const Text('Ownership')),
       body: Center(
+        // TODO: Add location/map icon (e.g. assets/icons/location.svg)
         child: Text('${s.lastSeenNear} Main St'),
       ),
     );

--- a/app/lib/ui/screens/ride_screen.dart
+++ b/app/lib/ui/screens/ride_screen.dart
@@ -32,6 +32,7 @@ class _RideScreenState extends State<RideScreen> {
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
+                // TODO: Display speed gauge asset (e.g. assets/images/speed_gauge.png)
                 Text('${speed.toStringAsFixed(1)} m/s',
                     style: Theme.of(context).textTheme.displayMedium),
                 const SizedBox(height: 20),

--- a/app/lib/ui/screens/rides_screen.dart
+++ b/app/lib/ui/screens/rides_screen.dart
@@ -10,6 +10,7 @@ class RidesScreen extends StatelessWidget {
       body: ListView.builder(
         itemCount: 0,
         itemBuilder: (context, index) => const ListTile(
+          // TODO: Add ride thumbnail asset (e.g. assets/images/ride_thumbnail.png)
           title: Text('Ride'),
         ),
       ),

--- a/app/lib/ui/screens/settings_screen.dart
+++ b/app/lib/ui/screens/settings_screen.dart
@@ -19,23 +19,33 @@ class SettingsScreen extends StatelessWidget {
       body: ListView(
         children: [
           ListTile(
+            // TODO: Add diagnostics icon (e.g. assets/icons/diagnostics.svg)
             title: Text(s.diagnostics),
             onTap: () => Navigator.of(context).pushNamed('/diagnostics'),
           ),
           const Divider(),
-          ListTile(title: Text(s.accessibility)),
+          ListTile(
+            // TODO: Add accessibility icon (e.g. assets/icons/accessibility.svg)
+            title: Text(s.accessibility),
+          ),
           SwitchListTile(
+            // TODO: Add high-contrast icon (e.g. assets/icons/contrast.svg)
             title: Text(s.highContrast),
             value: a11y.highContrast,
             onChanged: (v) => a11y.setHighContrast(v),
           ),
           const Divider(),
-          ListTile(title: Text(s.developer)),
           ListTile(
+            // TODO: Add developer icon (e.g. assets/icons/developer.svg)
+            title: Text(s.developer),
+          ),
+          ListTile(
+            // TODO: Add theft ping icon (e.g. assets/icons/theft_ping.svg)
             title: Text(s.simulateTheftPing),
             onTap: () => theft.simulatePing(),
           ),
           ListTile(
+            // TODO: Add crowd find icon (e.g. assets/icons/crowd_find.svg)
             title: Text(s.generateMockSighting),
             onTap: () => crowd.addSighting('MOCK', 37.0, -122.0),
           ),

--- a/app/lib/ui/screens/updates_screen.dart
+++ b/app/lib/ui/screens/updates_screen.dart
@@ -8,6 +8,7 @@ class UpdatesScreen extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(title: const Text('Updates')),
       body: const Center(
+        // TODO: Add firmware update illustration (e.g. assets/images/update.png)
         child: Text('Firmware update coming soon.'),
       ),
     );


### PR DESCRIPTION
## Summary
- add TODOs in UI screens for missing icons and illustrations
- expand asset manifest with required SVG/PNG assets

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7b9b881083279bd1c3f1846639a2