### PR TITLE
feat: add demo mode with dashboard and settings

### DIFF
--- a/app/lib/demo/demo_repository.dart
+++ b/app/lib/demo/demo_repository.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/foundation.dart';
+import '../models/telemetry.dart';
+import 'dart:async';
+import 'dart:math' as math;
+
+/// Provides mock data streams and fixtures for demo mode.
+class DemoRepository {
+  DemoRepository();
+
+  /// Stream of synthetic telemetry at 10 Hz.
+  Stream<Telemetry> telemetryStream() {
+    int ms = 0;
+    double volts = 42.0;
+    double esc = 30.0;
+    double motor = 35.0;
+    return Stream.periodic(const Duration(milliseconds: 100), (_) {
+      ms += 100;
+      final t = ms / 1000.0;
+      volts = math.max(30.0, volts - 0.0005);
+      esc = math.min(100.0, esc + 0.01);
+      motor = math.min(120.0, motor + 0.015);
+      final fault = (ms ~/ 5000) % 2 == 0 ? 0 : 1;
+      return Telemetry(
+        ts: DateTime.now(),
+        msSinceBoot: ms,
+        speedMps: 8 + 2 * math.sin(t),
+        volts: volts,
+        amps: 12 + 6 * math.cos(t),
+        escTempC: esc,
+        motorTempC: motor,
+        throttlePct: 60,
+        brakePct: 0,
+        rideMode: 1,
+        faultsBits: fault,
+      );
+    });
+  }
+
+  /// Recent mock ride summaries.
+  List<RideSummary> recentRides = const [
+    RideSummary(distanceKm: 5.2, durationMin: 18, topSpeedKph: 28, date: '2024-05-01'),
+    RideSummary(distanceKm: 12.4, durationMin: 42, topSpeedKph: 34, date: '2024-04-27'),
+    RideSummary(distanceKm: 3.1, durationMin: 10, topSpeedKph: 20, date: '2024-04-20'),
+  ];
+}
+
+@immutable
+class RideSummary {
+  final double distanceKm;
+  final int durationMin;
+  final double topSpeedKph;
+  final String date;
+  const RideSummary({
+    required this.distanceKm,
+    required this.durationMin,
+    required this.topSpeedKph,
+    required this.date,
+  });
+}

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -1,122 +1,73 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'settings/app_settings.dart';
+import 'settings/accessibility.dart';
+import 'ui/screens/ride_screen.dart';
+import 'ui/screens/rides_screen.dart';
+import 'ui/screens/modes_screen.dart';
+import 'ui/screens/diagnostics_screen.dart';
+import 'ui/screens/settings_screen.dart';
 
-void main() {
-  runApp(const MyApp());
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  final prefs = await SharedPreferences.getInstance();
+  runApp(MyApp(prefs: prefs));
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+  const MyApp({super.key, required this.prefs});
 
-  // This widget is the root of your application.
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
+  final SharedPreferences prefs;
 
   @override
   Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(create: (_) => AppSettings(prefs)),
+        ChangeNotifierProvider(create: (_) => AccessibilitySettings()),
+      ],
+      child: Consumer<AppSettings>(
+        builder: (context, settings, _) {
+          final theme = ThemeData(
+            brightness: Brightness.light,
+            useMaterial3: true,
+          );
+          final dark = ThemeData(
+            brightness: Brightness.dark,
+            useMaterial3: true,
+            cardTheme: CardTheme(
+              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+              elevation: 2,
             ),
-          ],
-        ),
+          );
+          final routes = ['/ride', '/rides', '/modes', '/diagnostics', '/settings'];
+          return MaterialApp(
+            title: 'X-Ray',
+            theme: theme,
+            darkTheme: dark,
+            themeMode: settings.themeMode,
+            builder: (context, child) {
+              final a11y = context.watch<AccessibilitySettings>();
+              return MediaQuery(
+                data: MediaQuery.of(context).copyWith(
+                  textScaleFactor: a11y.largeText ? 1.3 : 1.0,
+                  highContrast: a11y.highContrast,
+                ),
+                child: child!,
+              );
+            },
+            routes: {
+              '/ride': (_) => const RideScreen(),
+              '/rides': (_) => const RidesScreen(),
+              '/modes': (_) => const ModesScreen(),
+              '/diagnostics': (_) => const DiagnosticsScreen(),
+              '/settings': (_) => const SettingsScreen(),
+            },
+            initialRoute: routes[settings.lastTab],
+          );
+        },
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
     );
   }
 }

--- a/app/lib/settings/accessibility.dart
+++ b/app/lib/settings/accessibility.dart
@@ -2,9 +2,15 @@ import 'package:flutter/foundation.dart';
 
 class AccessibilitySettings extends ChangeNotifier {
   bool highContrast = false;
+  bool largeText = false;
 
   void setHighContrast(bool value) {
     highContrast = value;
+    notifyListeners();
+  }
+
+  void setLargeText(bool value) {
+    largeText = value;
     notifyListeners();
   }
 }

--- a/app/lib/settings/app_settings.dart
+++ b/app/lib/settings/app_settings.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Global application settings including demo mode and theming.
+class AppSettings extends ChangeNotifier {
+  AppSettings(this._prefs)
+      : demoMode = _prefs.getBool('demoMode') ?? kDebugMode,
+        lastTab = _prefs.getInt('lastTab') ?? 0,
+        metricUnits = _prefs.getBool('metricUnits') ?? true,
+        themeMode = ThemeMode.values[_prefs.getInt('themeMode') ?? 0];
+
+  final SharedPreferences _prefs;
+
+  bool demoMode;
+  int lastTab;
+  bool metricUnits;
+  ThemeMode themeMode;
+
+  void setDemoMode(bool v) {
+    demoMode = v;
+    _prefs.setBool('demoMode', v);
+    notifyListeners();
+  }
+
+  void setLastTab(int i) {
+    lastTab = i;
+    _prefs.setInt('lastTab', i);
+    notifyListeners();
+  }
+
+  void setMetricUnits(bool v) {
+    metricUnits = v;
+    _prefs.setBool('metricUnits', v);
+    notifyListeners();
+  }
+
+  void setThemeMode(ThemeMode mode) {
+    themeMode = mode;
+    _prefs.setInt('themeMode', mode.index);
+    notifyListeners();
+  }
+}

--- a/app/lib/ui/bottom_nav_scaffold.dart
+++ b/app/lib/ui/bottom_nav_scaffold.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../settings/app_settings.dart';
+
+/// Common scaffold with bottom navigation and shared routing.
+class BottomNavScaffold extends StatelessWidget {
+  const BottomNavScaffold({
+    super.key,
+    required this.index,
+    required this.title,
+    required this.body,
+  });
+
+  final int index;
+  final String title;
+  final Widget body;
+
+  @override
+  Widget build(BuildContext context) {
+    final settings = context.read<AppSettings>();
+    void onTap(int i) {
+      if (i == index) return;
+      settings.setLastTab(i);
+      const routes = ['/ride', '/rides', '/modes', '/diagnostics', '/settings'];
+      Navigator.pushReplacementNamed(context, routes[i]);
+    }
+
+    return Scaffold(
+      appBar: AppBar(title: Text(title)),
+      body: body,
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: index,
+        onTap: onTap,
+        items: const [
+          BottomNavigationBarItem(icon: Icon(Icons.speed), label: 'Ride'),
+          BottomNavigationBarItem(icon: Icon(Icons.list), label: 'Rides'),
+          BottomNavigationBarItem(icon: Icon(Icons.tune), label: 'Modes'),
+          BottomNavigationBarItem(icon: Icon(Icons.healing), label: 'Diagnostics'),
+          BottomNavigationBarItem(icon: Icon(Icons.settings), label: 'Settings'),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/ui/screens/connect_screen.dart
+++ b/app/lib/ui/screens/connect_screen.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import 'package:permission_handler/permission_handler.dart';
+import 'package:provider/provider.dart';
+import '../../settings/app_settings.dart';
 
 class ConnectScreen extends StatefulWidget {
   const ConnectScreen({super.key});
@@ -14,16 +16,14 @@ class _ConnectScreenState extends State<ConnectScreen> {
   bool _scanning = false;
 
   Future<bool> _ensureBlePermissions(BuildContext context) async {
+    if (context.read<AppSettings>().demoMode) return true;
     final statuses = await [
       Permission.bluetoothScan,
       Permission.bluetoothConnect,
-      Permission.locationWhenInUse, // needed for pre-Android 12 scanning
-      Permission.notification,      // optional (alerts)
+      Permission.locationWhenInUse,
+      Permission.notification,
     ].request();
-
-    // FIX: check the values of the returned Map
-    final granted = statuses.values.every((status) => status.isGranted || status.isLimited);
-
+    final granted = statuses.values.every((s) => s.isGranted || s.isLimited);
     if (!granted && mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Permissions are required to scan/connect')),

--- a/app/lib/ui/screens/diagnostics_screen.dart
+++ b/app/lib/ui/screens/diagnostics_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import '../../l10n/generated/l10n.dart';
+import '../bottom_nav_scaffold.dart';
 
 class DiagnosticsScreen extends StatelessWidget {
   const DiagnosticsScreen({super.key});
@@ -8,81 +9,30 @@ class DiagnosticsScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final s = S.of(context);
-    return Scaffold(
-      appBar: AppBar(title: Text(s.diagnostics)),
+    return BottomNavScaffold(
+      index: 3,
+      title: s.diagnostics,
       body: ListView(
         children: [
-          Semantics(
-            label: s.batteryHealth,
-            child: Card(
-              child: ListTile(
-                leading: SvgPicture.asset(
-                  'assets/icons/battery.svg',
-                  width: 24,
-                  height: 24,
-                ),
-                title: Text(s.batteryHealth),
-                subtitle: const Text('SOH: 95%'),
-              ),
-            ),
-          ),
-          Semantics(
-            label: s.sagRisk,
-            child: Card(
-              child: ListTile(
-                leading: SvgPicture.asset(
-                  'assets/icons/sag_risk.svg',
-                  width: 24,
-                  height: 24,
-                ),
-                title: Text(s.sagRisk),
-                subtitle: const Text('Low'),
-              ),
-            ),
-          ),
-          Semantics(
-            label: s.escTemps,
-            child: Card(
-              child: ListTile(
-                leading: SvgPicture.asset(
-                  'assets/icons/esc_temp.svg',
-                  width: 24,
-                  height: 24,
-                ),
-                title: Text(s.escTemps),
-                subtitle: const Text('ETA 10m'),
-              ),
-            ),
-          ),
-          Semantics(
-            label: s.faultsLog,
-            child: Card(
-              child: ListTile(
-                leading: SvgPicture.asset(
-                  'assets/icons/fault.svg',
-                  width: 24,
-                  height: 24,
-                ),
-                title: Text(s.faultsLog),
-                subtitle: const Text('No recent faults'),
-              ),
-            ),
-          ),
-          Semantics(
-            label: s.maintenanceTips,
-            child: Card(
-              child: ListTile(
-                leading: SvgPicture.asset(
-                  'assets/icons/maintenance.svg',
-                  width: 24,
-                  height: 24,
-                ),
-                title: Text(s.maintenanceTips),
-                subtitle: const Text('Keep tires inflated.'),
-              ),
-            ),
-          ),
+          _card('assets/icons/battery.svg', s.batteryHealth, 'SOH: 95%'),
+          _card('assets/icons/sag_risk.svg', s.sagRisk, 'Low'),
+          _card('assets/icons/esc_temp.svg', s.escTemps, 'ETA 10m'),
+          _card('assets/icons/fault.svg', s.faultsLog, 'No recent faults'),
+          _card('assets/icons/maintenance.svg', s.maintenanceTips, 'Keep tires inflated.'),
         ],
+      ),
+    );
+  }
+
+  Widget _card(String asset, String title, String subtitle) {
+    return Semantics(
+      label: title,
+      child: Card(
+        child: ListTile(
+          leading: SvgPicture.asset(asset, width: 24, height: 24),
+          title: Text(title),
+          subtitle: Text(subtitle),
+        ),
       ),
     );
   }

--- a/app/lib/ui/screens/modes_screen.dart
+++ b/app/lib/ui/screens/modes_screen.dart
@@ -1,41 +1,51 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:provider/provider.dart';
+import '../../settings/app_settings.dart';
+import '../bottom_nav_scaffold.dart';
 
-class ModesScreen extends StatelessWidget {
+class ModesScreen extends StatefulWidget {
   const ModesScreen({super.key});
 
   @override
+  State<ModesScreen> createState() => _ModesScreenState();
+}
+
+class _ModesScreenState extends State<ModesScreen> {
+  int _mode = 0;
+
+  @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Modes')),
+    final app = context.watch<AppSettings>();
+    void select(int m) {
+      setState(() => _mode = m);
+      if (app.demoMode) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Mode set to $m')),
+        );
+      }
+    }
+
+    return BottomNavScaffold(
+      index: 2,
+      title: 'Modes',
       body: ListView(
         children: [
-          ListTile(
-            leading: SvgPicture.asset(
-              'assets/icons/mode_eco.svg',
-              width: 24,
-              height: 24,
-            ),
-            title: const Text('Eco'),
-          ),
-          ListTile(
-            leading: SvgPicture.asset(
-              'assets/icons/mode_sport.svg',
-              width: 24,
-              height: 24,
-            ),
-            title: const Text('Sport'),
-          ),
-          ListTile(
-            leading: SvgPicture.asset(
-              'assets/icons/mode_pro.svg',
-              width: 24,
-              height: 24,
-            ),
-            title: const Text('Pro'),
-          ),
+          _tile('Eco', 'assets/icons/mode_eco.svg', 0, select),
+          _tile('Sport', 'assets/icons/mode_sport.svg', 1, select),
+          _tile('Pro', 'assets/icons/mode_pro.svg', 2, select),
+          _tile('Turbo', 'assets/icons/turbo.svg', 3, select),
         ],
       ),
+    );
+  }
+
+  Widget _tile(String title, String asset, int value, void Function(int) onTap) {
+    return ListTile(
+      leading: SvgPicture.asset(asset, width: 24, height: 24),
+      title: Text(title),
+      trailing: Radio<int>(value: value, groupValue: _mode, onChanged: (_) => onTap(value)),
+      onTap: () => onTap(value),
     );
   }
 }

--- a/app/lib/ui/screens/ride_screen.dart
+++ b/app/lib/ui/screens/ride_screen.dart
@@ -1,6 +1,10 @@
+import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
-import '../../ble/mock_profile.dart';
+import 'package:provider/provider.dart';
+import '../../demo/demo_repository.dart';
 import '../../models/telemetry.dart';
+import '../../settings/app_settings.dart';
+import '../bottom_nav_scaffold.dart';
 
 class RideScreen extends StatefulWidget {
   const RideScreen({super.key});
@@ -10,40 +14,116 @@ class RideScreen extends StatefulWidget {
 }
 
 class _RideScreenState extends State<RideScreen> {
-  final _profile = MockProfile();
   late final Stream<Telemetry> _stream;
+  final _speedHistory = <FlSpot>[];
+  final _ampHistory = <FlSpot>[];
+  int _idx = 0;
 
   @override
   void initState() {
     super.initState();
-    _stream = _profile.startMockStream();
+    _stream = DemoRepository().telemetryStream();
   }
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Ride')),
+    final settings = context.watch<AppSettings>();
+    return BottomNavScaffold(
+      index: 0,
+      title: 'Ride',
       body: StreamBuilder<Telemetry>(
         stream: _stream,
         builder: (context, snapshot) {
           final t = snapshot.data;
-          final speed = t?.speedMps ?? 0;
-          return Center(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                // TODO: Display speed gauge asset (e.g. assets/images/speed_gauge.png)
-                Text('${speed.toStringAsFixed(1)} m/s',
-                    style: Theme.of(context).textTheme.displayMedium),
-                const SizedBox(height: 20),
-                ElevatedButton(
-                  onPressed: () => Navigator.pushNamed(context, '/modes'),
-                  child: const Text('Modes'),
+          if (t != null) {
+            _speedHistory.add(FlSpot(_idx.toDouble(), t.speedMps));
+            _ampHistory.add(FlSpot(_idx.toDouble(), t.amps));
+            _idx++;
+            if (_speedHistory.length > 300) {
+              _speedHistory.removeAt(0);
+              _ampHistory.removeAt(0);
+            }
+          }
+          return ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              if (settings.demoMode)
+                const Align(
+                  alignment: Alignment.center,
+                  child: Chip(label: Text('Demo board connected')),
                 ),
-              ],
-            ),
+              const SizedBox(height: 12),
+              _statGrid(t),
+              const SizedBox(height: 16),
+              SizedBox(
+                height: 100,
+                child: LineChart(
+                  LineChartData(
+                    titlesData: FlTitlesData(show: false),
+                    gridData: FlGridData(show: false),
+                    borderData: FlBorderData(show: false),
+                    lineBarsData: [
+                      LineChartBarData(
+                        spots: _speedHistory,
+                        isCurved: true,
+                        color: Colors.lightBlueAccent,
+                        dotData: FlDotData(show: false),
+                      ),
+                      LineChartBarData(
+                        spots: _ampHistory,
+                        isCurved: true,
+                        color: Colors.greenAccent,
+                        dotData: FlDotData(show: false),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
           );
         },
+      ),
+    );
+  }
+
+  Widget _statGrid(Telemetry? t) {
+    final speed = t?.speedMps ?? 0;
+    final volts = t?.volts ?? 0;
+    final amps = t?.amps ?? 0;
+    final esc = t?.escTempC ?? 0;
+    final motor = t?.motorTempC ?? 0;
+    final powerKw = volts * amps / 1000;
+    final range = (volts - 30) * 2; // crude
+    final fault = t?.faultsBits ?? 0;
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: [
+        _card('Speed', '${(speed * 3.6).toStringAsFixed(1)} km/h'),
+        _card('Battery', '${(volts / 42 * 100).toStringAsFixed(0)}%'),
+        _card('Temps', 'ESC ${esc.toStringAsFixed(0)}°C / M ${motor.toStringAsFixed(0)}°C'),
+        _card('Power', '${powerKw.toStringAsFixed(1)} kW'),
+        _card('Range ETA', '${range.toStringAsFixed(0)} km'),
+        if (fault != 0) _card('Fault', 'Code $fault'),
+      ],
+    );
+  }
+
+  Widget _card(String title, String value) {
+    return SizedBox(
+      width: 160,
+      child: Card(
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(title, style: const TextStyle(fontWeight: FontWeight.bold)),
+              const SizedBox(height: 4),
+              Text(value, style: Theme.of(context).textTheme.bodyLarge),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/app/lib/ui/screens/rides_screen.dart
+++ b/app/lib/ui/screens/rides_screen.dart
@@ -1,18 +1,28 @@
 import 'package:flutter/material.dart';
+import '../../demo/demo_repository.dart';
+import '../bottom_nav_scaffold.dart';
 
 class RidesScreen extends StatelessWidget {
   const RidesScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Rides')),
-      body: ListView.builder(
-        itemCount: 0,
-        itemBuilder: (context, index) => const ListTile(
-          // TODO: Add ride thumbnail asset (e.g. assets/images/ride_thumbnail.png)
-          title: Text('Ride'),
-        ),
+    final repo = DemoRepository();
+    return BottomNavScaffold(
+      index: 1,
+      title: 'Rides',
+      body: ListView.separated(
+        itemCount: repo.recentRides.length,
+        separatorBuilder: (_, __) => const Divider(height: 1),
+        itemBuilder: (context, i) {
+          final r = repo.recentRides[i];
+          return ListTile(
+            title: Text('${r.distanceKm.toStringAsFixed(1)} km • ${r.durationMin}m'),
+            subtitle: Text('Top ${r.topSpeedKph.toStringAsFixed(1)} km/h'),
+            trailing: Text(r.date),
+            onTap: () {},
+          );
+        },
       ),
     );
   }

--- a/app/lib/ui/screens/settings_screen.dart
+++ b/app/lib/ui/screens/settings_screen.dart
@@ -1,10 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:permission_handler/permission_handler.dart';
 import 'package:provider/provider.dart';
 import '../../l10n/generated/l10n.dart';
 import '../../settings/accessibility.dart';
+import '../../settings/app_settings.dart';
 import '../../security/theft_monitor.dart';
 import '../../security/crowd_find.dart';
+import '../bottom_nav_scaffold.dart';
 
 class SettingsScreen extends StatelessWidget {
   const SettingsScreen({super.key});
@@ -12,67 +16,87 @@ class SettingsScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final s = S.of(context);
+    final app = context.watch<AppSettings>();
     final a11y = context.watch<AccessibilitySettings>();
     final theft = context.read<TheftMonitor>();
     final crowd = context.read<CrowdFindService>();
-    return Scaffold(
-      appBar: AppBar(title: Text(s.settings)),
+    return BottomNavScaffold(
+      index: 4,
+      title: s.settings,
       body: ListView(
         children: [
+          SwitchListTile(
+            secondary: SvgPicture.asset('assets/icons/ble_board.svg', width: 24, height: 24),
+            title: const Text('Enable Demo Mode'),
+            value: app.demoMode,
+            onChanged: app.setDemoMode,
+          ),
+          SwitchListTile(
+            secondary: SvgPicture.asset('assets/icons/location.svg', width: 24, height: 24),
+            title: const Text('Use metric units'),
+            value: app.metricUnits,
+            onChanged: app.setMetricUnits,
+          ),
           ListTile(
-            leading: SvgPicture.asset(
-              'assets/icons/diagnostics.svg',
-              width: 24,
-              height: 24,
+            leading: const Icon(Icons.brightness_6),
+            title: const Text('Theme'),
+            trailing: DropdownButton<ThemeMode>(
+              value: app.themeMode,
+              items: const [
+                DropdownMenuItem(value: ThemeMode.system, child: Text('System')),
+                DropdownMenuItem(value: ThemeMode.light, child: Text('Light')),
+                DropdownMenuItem(value: ThemeMode.dark, child: Text('Dark')),
+              ],
+              onChanged: (m) {
+                if (m != null) app.setThemeMode(m);
+              },
             ),
+          ),
+          SwitchListTile(
+            secondary: SvgPicture.asset('assets/icons/accessibility.svg', width: 24, height: 24),
+            title: const Text('Larger text'),
+            value: a11y.largeText,
+            onChanged: a11y.setLargeText,
+          ),
+          SwitchListTile(
+            secondary: SvgPicture.asset('assets/icons/contrast.svg', width: 24, height: 24),
+            title: s.highContrast,
+            value: a11y.highContrast,
+            onChanged: a11y.setHighContrast,
+          ),
+          ListTile(
+            leading: SvgPicture.asset('assets/icons/diagnostics.svg', width: 24, height: 24),
             title: Text(s.diagnostics),
             onTap: () => Navigator.of(context).pushNamed('/diagnostics'),
           ),
-          const Divider(),
           ListTile(
-            leading: SvgPicture.asset(
-              'assets/icons/accessibility.svg',
-              width: 24,
-              height: 24,
-            ),
-            title: Text(s.accessibility),
-          ),
-          SwitchListTile(
-            secondary: SvgPicture.asset(
-              'assets/icons/contrast.svg',
-              width: 24,
-              height: 24,
-            ),
-            title: Text(s.highContrast),
-            value: a11y.highContrast,
-            onChanged: (v) => a11y.setHighContrast(v),
-          ),
-          const Divider(),
-          ListTile(
-            leading: SvgPicture.asset(
-              'assets/icons/developer.svg',
-              width: 24,
-              height: 24,
-            ),
-            title: Text(s.developer),
-          ),
-          ListTile(
-            leading: SvgPicture.asset(
-              'assets/icons/theft_ping.svg',
-              width: 24,
-              height: 24,
-            ),
+            leading: SvgPicture.asset('assets/icons/theft_ping.svg', width: 24, height: 24),
             title: Text(s.simulateTheftPing),
             onTap: () => theft.simulatePing(),
           ),
           ListTile(
-            leading: SvgPicture.asset(
-              'assets/icons/crowd_find.svg',
-              width: 24,
-              height: 24,
-            ),
+            leading: SvgPicture.asset('assets/icons/crowd_find.svg', width: 24, height: 24),
             title: Text(s.generateMockSighting),
             onTap: () => crowd.addSighting('MOCK', 37.0, -122.0),
+          ),
+          ListTile(
+            leading: const Icon(Icons.bluetooth),
+            title: const Text('Request BLE permissions'),
+            onTap: () => [
+              Permission.bluetoothScan,
+              Permission.bluetoothConnect,
+              Permission.locationWhenInUse,
+            ].request(),
+          ),
+          FutureBuilder<PackageInfo>(
+            future: PackageInfo.fromPlatform(),
+            builder: (context, snap) {
+              final ver = snap.data?.version ?? '';
+              return ListTile(
+                title: const Text('App Version'),
+                subtitle: Text(ver),
+              );
+            },
           ),
         ],
       ),

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -34,6 +34,18 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  provider: ^6.0.5
+  flutter_svg: ^2.0.9
+  flutter_blue_plus: ^1.21.5
+  permission_handler: ^11.3.0
+  shared_preferences: ^2.2.2
+  fl_chart: ^0.66.2
+  package_info_plus: ^5.0.1
+  drift: ^2.15.0
+  drift_sqflite: ^2.5.0
+  flutter_localizations:
+    sdk: flutter
+  intl: ^0.18.1
 
 dev_dependencies:
   flutter_test:
@@ -45,6 +57,8 @@ dev_dependencies:
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
   flutter_lints: ^5.0.0
+  drift_dev: ^2.15.0
+  build_runner: ^2.4.8
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
@@ -56,34 +70,10 @@ flutter:
   # included with your application, so that you can use the icons in
   # the material Icons class.
   uses-material-design: true
-
-  # To add assets to your application, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/to/resolution-aware-images
-
-  # For details regarding adding assets from package dependencies, see
-  # https://flutter.dev/to/asset-from-package
-
-  # To add custom fonts to your application, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts from package dependencies,
-  # see https://flutter.dev/to/font-from-package
+  assets:
+    - assets/configList.json
+    - assets/device-detail_definition.json
+    - assets/deviceDetail.json
+    - assets/dynamic_config.json
+    - assets/kit_dependence/
+    - assets/icons/

--- a/app/test/dashboard_diagnostics_test.dart
+++ b/app/test/dashboard_diagnostics_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:exwayapp/settings/app_settings.dart';
+import 'package:exwayapp/settings/accessibility.dart';
+import 'package:exwayapp/ui/screens/ride_screen.dart';
+import 'package:exwayapp/ui/screens/diagnostics_screen.dart';
+
+void main() {
+  testWidgets('Ride screen shows demo chip', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final app = AppSettings(prefs)..setDemoMode(true);
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider.value(value: app),
+          ChangeNotifierProvider(create: (_) => AccessibilitySettings()),
+        ],
+        child: const MaterialApp(home: RideScreen()),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 200));
+    expect(find.text('Demo board connected'), findsOneWidget);
+  });
+
+  testWidgets('Diagnostics screen renders cards', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final app = AppSettings(prefs);
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider.value(value: app),
+          ChangeNotifierProvider(create: (_) => AccessibilitySettings()),
+        ],
+        child: const MaterialApp(home: DiagnosticsScreen()),
+      ),
+    );
+    expect(find.text('Battery Health'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add AppSettings provider and persistent demo mode toggle
- implement bottom navigation with ride dashboard using mock telemetry
- expand settings with theme, unit, accessibility options and BLE permission button
- add basic widget tests for ride dashboard and diagnostics cards

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart run build_runner build --delete-conflicting-outputs` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acf81db62c8327836db942dd607f96